### PR TITLE
added an optional parameter to the send function (issue from March 25, 2011)

### DIFF
--- a/classes/email.php
+++ b/classes/email.php
@@ -78,9 +78,10 @@ class Email {
 	 * @param   string        message subject
 	 * @param   string        message body
 	 * @param   boolean       send email as HTML
+	 * @param   string	  encoding type to use ('7-bit', '8-bit', 'base64' or 'qp'
 	 * @return  integer       number of emails sent
 	 */
-	public static function send($to, $from, $subject, $message, $html = FALSE)
+	public static function send($to, $from, $subject, $message, $html = FALSE, $encoding = NULL)
 	{
 		// Connect to SwiftMailer
 		(Email::$mail === NULL) and email::connect();
@@ -90,6 +91,25 @@ class Email {
 
 		// Create the message
 		$message = Swift_Message::newInstance($subject, $message, $html, 'utf-8');
+
+		if ( ! is_null($encoding))
+		{
+			switch ($encoding)
+			{
+				case '7-bit':
+					$message->setEncoder(Swift_Encoding::get7BitEncoding());
+					break;
+				case '8-bit':
+					$message->setEncoder(Swift_Encoding::get8BitEncoding());
+					break;
+				case 'base64':
+					$message->setEncoder(Swift_Encoding::getBase64Encoding());
+					break;
+				case 'qp':
+					$message->setEncoder(Swift_Encoding::getQpEncoding());
+					break;
+			}
+		}
 
 		if (is_string($to))
 		{
@@ -142,4 +162,4 @@ class Email {
 		return Email::$mail->send($message);
 	}
 
-} // End email
+} // End emailef


### PR DESCRIPTION
Hi banks,

i added the optional $encoding parameter to the send function to set the encoder after the message was instanciated. 
I think that is the easiest way for the user to set the encoder when calling the send function.

What do you think?
Chris
